### PR TITLE
Add SerializedType for Doctrine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+8.1.0
+=====
+
+*   (feature) Added new Doctrine Type `serialized`, that behaves exactly like the built-in `object` but base64 encode's the serialized data on top,
+    to prevent silent errors that can occur when creating or restoring a backup. See https://www.doctrine-project.org/projects/doctrine-dbal/en/2.10/reference/types.html#object for references.
+
+
 8.0.3
 =====
 

--- a/src/BecklynRadBundle.php
+++ b/src/BecklynRadBundle.php
@@ -3,7 +3,9 @@
 namespace Becklyn\Rad;
 
 use Becklyn\Rad\DependencyInjection\DoctrineExtensionsCompilerPass;
+use Becklyn\Rad\Doctrine\Types\SerializedType;
 use Becklyn\RadBundles\Bundle\BundleExtension;
+use Doctrine\DBAL\Types\Type;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -35,5 +37,16 @@ class BecklynRadBundle extends Bundle
     public function getPath () : string
     {
         return \dirname(__DIR__);
+    }
+
+
+    /**
+     * @inheritDoc
+     */
+    public function boot () : void
+    {
+        parent::boot();
+
+        Type::addType(SerializedType::NAME, SerializedType::class);
     }
 }

--- a/src/Doctrine/Types/SerializedType.php
+++ b/src/Doctrine/Types/SerializedType.php
@@ -1,0 +1,78 @@
+<?php declare(strict_types=1);
+
+namespace Becklyn\Rad\Doctrine\Types;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\Type;
+
+/**
+ * Type that maps a PHP object to a clob SQL type.
+ */
+class SerializedType extends Type
+{
+    public const NAME = "serialized";
+
+
+    /**
+     * @inheritDoc
+     */
+    public function getSQLDeclaration (array $fieldDeclaration, AbstractPlatform $platform) : string
+    {
+        return $platform->getClobTypeDeclarationSQL($fieldDeclaration);
+    }
+
+
+    /**
+     * @inheritDoc
+     */
+    public function convertToDatabaseValue ($value, AbstractPlatform $platform) : string
+    {
+        return \base64_encode(\serialize($value));
+    }
+
+
+    /**
+     * @inheritDoc
+     */
+    public function convertToPHPValue ($value, AbstractPlatform $platform) : ?string
+    {
+        if (null === $value)
+        {
+            return null;
+        }
+
+        $value = \is_resource($value) ? \stream_get_contents($value) : $value;
+
+        \set_error_handler(function (int $code, string $message) : bool {
+            throw ConversionException::conversionFailedUnserialization($this->getName(), $message);
+        });
+
+        try
+        {
+            return \unserialize(\base64_decode($value, true));
+        }
+        finally
+        {
+            \restore_error_handler();
+        }
+    }
+
+
+    /**
+     * @inheritDoc
+     */
+    public function getName () : string
+    {
+        return self::NAME;
+    }
+
+
+    /**
+     * @inheritDoc
+     */
+    public function requiresSQLCommentHint (AbstractPlatform $platform) : bool
+    {
+        return true;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | --------------------------------------------------------------------- |
| BC breaks?    |no                                                                |
| New feature?  | yes<!-- don't forget to update CHANGELOG.md -->                   |
| Improvement?  |no <!-- improves an existing feature, not adding a new one -->    |
| Bug fix?      |no                                                                |
| Deprecations? |no <!-- don't forget to update UPGRADE.md and CHANGELOG.md -->    |
| Docs PR       | **missing** <!-- insert URL here -->                                  |

Added new Doctrine Type `serialized`, that behaves exactly like the built-in `object` but base64 encode's the serialized data on top,
    to prevent silent errors that can occur when creating or restoring a backup. See https://www.doctrine-project.org/projects/doctrine-dbal/en/2.10/reference/types.html#object for references.
