### PR TITLE
Remove wrong type declaration from `convertToPHPValue` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+8.1.2
+=====
+
+*   (bug) Fix return type of Doctrine Type `serialized`.
+
+
 8.1.1
 =====
 

--- a/src/Doctrine/Types/SerializedType.php
+++ b/src/Doctrine/Types/SerializedType.php
@@ -34,8 +34,10 @@ class SerializedType extends Type
 
     /**
      * @inheritDoc
+     *
+     * @return mixed
      */
-    public function convertToPHPValue ($value, AbstractPlatform $platform) : ?string
+    public function convertToPHPValue ($value, AbstractPlatform $platform)
     {
         if (null === $value)
         {


### PR DESCRIPTION
| Q             | A
| ------------- | --------------------------------------------------------------------- |
| BC breaks?    | no                                                                |
| New feature?  |no <!-- don't forget to update CHANGELOG.md -->                   |
| Improvement?  |no <!-- improves an existing feature, not adding a new one -->    |
| Bug fix?      | yes                                                               |
| Deprecations? |no <!-- don't forget to update UPGRADE.md and CHANGELOG.md -->    |
| Docs PR       | **missing** <!-- insert URL here -->                                  |

Fix return type of Doctrine Type `serialized`.
