### PR TITLE
Fix `PaginatedList::createFromArray()` `numberOfItems` calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+8.1.5
+=====
+
+*   (bug) Fix `PaginatedList::createFromArray()` `numberOfItems` calculation.
+
+
 8.1.4
 =====
 

--- a/src/Pagination/Data/PaginatedList.php
+++ b/src/Pagination/Data/PaginatedList.php
@@ -46,7 +46,7 @@ class PaginatedList
 
         return new self(
             $list,
-            new Pagination(1, $itemsPerPage, $itemsPerPage)
+            new Pagination(1, $itemsPerPage, \count($list))
         );
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | --------------------------------------------------------------------- |
| BC breaks?    |no                                                                |
| New feature?  |no <!-- don't forget to update CHANGELOG.md -->                   |
| Improvement?  |no <!-- improves an existing feature, not adding a new one -->    |
| Bug fix?      | yes                                                               |
| Deprecations? |no <!-- don't forget to update UPGRADE.md and CHANGELOG.md -->    |
| Docs PR       | **missing** <!-- insert URL here -->                                  |

Fix `PaginatedList::createFromArray()` `numberOfItems` calculation
