### PR TITLE
Add new Twig filter `transDeferred`, which accepts either a `DeferredTranslation` or a `string` translation key

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # LTE
-* @keichinger
+* @keichinger @jesko-plitt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+8.2.0
+=====
+
+*   (feature) Add new Twig filter `transDeferred`, which accepts either a `DeferredTranslation` or a `string` translation key.
+
+
 8.1.5
 =====
 

--- a/tests/Twig/RadTwigExtensionTest.php
+++ b/tests/Twig/RadTwigExtensionTest.php
@@ -2,15 +2,24 @@
 
 namespace Tests\Becklyn\Rad\Twig;
 
+use Becklyn\Rad\Exception\UnexpectedTypeException;
 use Becklyn\Rad\Html\DataContainer;
+use Becklyn\Rad\Translation\DeferredTranslation;
 use Becklyn\Rad\Twig\RadTwigExtension;
 use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
+/**
+ * @group twig
+ */
 class RadTwigExtensionTest extends TestCase
 {
     public function testAppendToKey () : void
     {
-        $extension = new RadTwigExtension(new DataContainer());
+        $extension = new RadTwigExtension(
+            new DataContainer(),
+            $this->createMock(TranslatorInterface::class)
+        );
         $array = [
             "existing" => "abc",
         ];
@@ -58,7 +67,83 @@ class RadTwigExtensionTest extends TestCase
      */
     public function testClassnames (array $classnames, string $expected) : void
     {
-        $extension = new RadTwigExtension(new DataContainer());
+        $extension = new RadTwigExtension(
+            new DataContainer(),
+            $this->createMock(TranslatorInterface::class)
+        );
         self::assertSame($extension->formatClassNames($classnames), $expected);
+    }
+
+
+    public function provideDeferredTransStringValues () : array
+    {
+        return [
+            "string" => [
+                "a.b.c",
+                [],
+                "messages",
+                "foo.bar",
+            ],
+            "string with arguments" => [
+                "a.b.c",
+                [
+                    "a" => 1,
+                    "b" => 2,
+                ],
+                "backend",
+                "baz.bar",
+            ],
+        ];
+    }
+
+
+    /**
+     * @dataProvider provideDeferredTransStringValues
+     */
+    public function testTransDeferredWithStringValues (string $message, array $arguments, string $domain, string $expected) : void
+    {
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator
+            ->expects(self::once())
+            ->method("trans")
+            ->with($message, $arguments, $domain)
+            ->willReturn($expected);
+
+        $extension = new RadTwigExtension(new DataContainer(), $translator);
+
+        self::assertSame($extension->transDeferred($message, $arguments, $domain), $expected);
+    }
+
+
+    public function provideDeferredTransWithDeferredTranslation () : array
+    {
+        return [
+            "string" => [
+                new DeferredTranslation("a.b.c", [], "messages"),
+                "foo.bar",
+            ],
+            "string with arguments" => [
+                new DeferredTranslation("a.b.c", ["a" => 1, "b" => 2], "backend"),
+                "baz.bar",
+            ],
+        ];
+    }
+
+
+    /**
+     * @dataProvider provideDeferredTransWithDeferredTranslation
+     */
+    public function testTransDeferredWithDeferredTranslation (DeferredTranslation $deferredTranslation, string $expected) : void
+    {
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator
+            ->expects(self::once())
+            ->method("trans")
+            ->with($deferredTranslation->getId(), $deferredTranslation->getParameters(), $deferredTranslation->getDomain())
+            ->willReturn($expected);
+
+        $extension = new RadTwigExtension(new DataContainer(), $translator);
+
+        self::assertSame($extension->transDeferred($deferredTranslation), $expected);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | --------------------------------------------------------------------- |
| BC breaks?    |no                                                                |
| New feature?  | yes<!-- don't forget to update CHANGELOG.md -->                   |
| Improvement?  |no <!-- improves an existing feature, not adding a new one -->    |
| Bug fix?      |no                                                                |
| Deprecations? |no <!-- don't forget to update UPGRADE.md and CHANGELOG.md -->    |
| Docs PR       | **missing** <!-- insert URL here -->                                  |

<!-- describe your changes below -->
