### PR TITLE
Upgrade to PHP 8.1+

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @keichinger @jesko-plitt
+* @rafaelsouzaf @mangoischke

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,13 +23,15 @@ jobs:
               run: composer install
 
             - name: Configure Composer Plugin Permissions
-              run: composer global config --no-plugins allow-plugins.bamarni/composer-bin-plugin true
+              run: |
+                  composer config allow-plugins.bamarni/composer-bin-plugin true
+                  composer config allow-plugins.ergebnis/composer-normalize true
 
             - name: Composer Plugins
-              run: composer global require ergebnis/composer-normalize bamarni/composer-bin-plugin php-coveralls/php-coveralls --no-interaction --prefer-dist --no-progress
+              run: composer require --dev ergebnis/composer-normalize bamarni/composer-bin-plugin --no-interaction --prefer-dist --no-progress
 
             - name: Composer Vendor-Bin Dependencies
-              run: composer bin all install --no-interaction --prefer-dist --no-progress --no-suggest
+              run: composer bin all install --no-interaction --prefer-dist --no-progress
 
             - name: Create Build Logs Directory
               run: mkdir -p build/logs

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,10 +7,10 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                php-versions: ['7.4', '8.0', '8.1']
+                php-versions: ['8.1', '8.2', '8.3']
         name: PHP ${{ matrix.php-versions }} Testing
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
               with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,8 +22,11 @@ jobs:
             - name: Composer Install
               run: composer install
 
+            - name: Configure Composer Plugin Permissions
+              run: composer global config --no-plugins allow-plugins.bamarni/composer-bin-plugin true
+
             - name: Composer Plugins
-              run: composer global require ergebnis/composer-normalize bamarni/composer-bin-plugin php-coveralls/php-coveralls --no-interaction --prefer-dist --no-progress --no-suggest --no-suggest
+              run: composer global require ergebnis/composer-normalize bamarni/composer-bin-plugin php-coveralls/php-coveralls --no-interaction --prefer-dist --no-progress
 
             - name: Composer Vendor-Bin Dependencies
               run: composer bin all install --no-interaction --prefer-dist --no-progress --no-suggest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+9.0.0
+=====
+
+*   (breaking) Minimum PHP version increased to 8.1.
+*   (breaking) All Doctrine ORM annotations converted to PHP 8 attributes.
+
+
 8.6.1
 =====
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -3,7 +3,6 @@
 
 *   The minimum PHP version has been increased from **7.4** to **8.1**.
 *   All Doctrine ORM annotations have been converted to PHP 8 attributes.
-*   Update your entities to use attributes instead of annotations (e.g., `#[ORM\Entity]` instead of `@ORM\Entity`).
 
 
 7.x to 8.0

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,3 +1,11 @@
+8.x to 9.0
+==========
+
+*   The minimum PHP version has been increased from **7.4** to **8.1**.
+*   All Doctrine ORM annotations have been converted to PHP 8 attributes.
+*   Update your entities to use attributes instead of annotations (e.g., `#[ORM\Entity]` instead of `@ORM\Entity`).
+
+
 7.x to 8.0
 ==========
 

--- a/composer.json
+++ b/composer.json
@@ -24,9 +24,9 @@
         "symfony/form": "^5.4.3 || ^6.0.3",
         "symfony/http-kernel": "^5.4.3 || ^6.0.4",
         "symfony/property-access": "^5.4.3 || ^6.0.3",
-        "symfony/translation-contracts": "^v2.5.0 || ^v3.0.0",
+        "symfony/translation-contracts": "^2.5.0 || ^3.0.0",
         "symfony/validator": "^5.4.3 || ^6.0.3",
-        "twig/twig": "^v3.3.4"
+        "twig/twig": "^3.3.4"
     },
     "require-dev": {
         "algolia/search-bundle": "^5.2.1 || ^6.0.0",

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "homepage": "https://github.com/Becklyn/rad",
     "require": {
-        "php": ">=7.4",
+        "php": ">=8.1",
         "ext-json": "*",
         "beberlei/doctrineextensions": "^1.3.0",
         "becklyn/rad-bundles": "^1.1.0",

--- a/composer.json
+++ b/composer.json
@@ -51,6 +51,10 @@
         }
     },
     "config": {
+        "allow-plugins": {
+            "bamarni/composer-bin-plugin": true,
+            "ergebnis/composer-normalize": true
+        },
         "sort-packages": true
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -15,24 +15,24 @@
         "ext-json": "*",
         "beberlei/doctrineextensions": "^1.3.0",
         "becklyn/rad-bundles": "^1.1.0",
-        "doctrine/doctrine-bundle": "^2.3.2",
-        "doctrine/orm": "^2.10.3",
+        "doctrine/doctrine-bundle": "^2.5.6",
+        "doctrine/orm": "^2.11.1",
         "psr/log": "^1.1.4",
         "scienta/doctrine-json-functions": "^4.5.0 || ^5.0.0",
-        "symfony/config": "^5.4.3 || ^6.0.3",
-        "symfony/dependency-injection": "^5.4.3 || ^6.0.3",
-        "symfony/form": "^5.4.3 || ^6.0.3",
-        "symfony/http-kernel": "^5.4.3 || ^6.0.4",
-        "symfony/property-access": "^5.4.3 || ^6.0.3",
-        "symfony/translation-contracts": "^2.5.0 || ^3.0.0",
-        "symfony/validator": "^5.4.3 || ^6.0.3",
-        "twig/twig": "^3.3.4"
+        "symfony/config": "^6.4",
+        "symfony/dependency-injection": "^6.4",
+        "symfony/form": "^6.4",
+        "symfony/http-kernel": "^6.4",
+        "symfony/property-access": "^6.4",
+        "symfony/translation-contracts": "^3.0.0",
+        "symfony/validator": "^6.4",
+        "twig/twig": "^3.3.8"
     },
     "require-dev": {
         "algolia/search-bundle": "^5.2.1 || ^6.0.0",
         "roave/security-advisories": "dev-master",
-        "symfony/phpunit-bridge": "^5.4.3 || ^6.0.3",
-        "symfony/twig-bridge": "^5.4.3 || ^6.0.3"
+        "symfony/phpunit-bridge": "^6.4",
+        "symfony/twig-bridge": "^6.4"
     },
     "conflict": {
         "becklyn/rad-bundle": "*"

--- a/src/Ajax/AjaxResponseBuilder.php
+++ b/src/Ajax/AjaxResponseBuilder.php
@@ -17,17 +17,9 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  */
 class AjaxResponseBuilder
 {
-    /** @var TranslatorInterface */
-    protected $translator;
+    protected bool $ok;
 
-    /** @var UrlGeneratorInterface */
-    protected $urlGenerator;
-
-    /** @var bool */
-    protected $ok;
-
-    /** @var string */
-    protected $status;
+    protected ?string $status;
 
     /** @var DeferredRoute|string|null */
     protected $redirect;
@@ -51,8 +43,8 @@ class AjaxResponseBuilder
     /**
      */
     public function __construct (
-        TranslatorInterface $translator,
-        UrlGeneratorInterface $urlGenerator,
+        protected TranslatorInterface $translator,
+        protected UrlGeneratorInterface $urlGenerator,
         bool $ok,
         ?string $status = null
     )
@@ -61,9 +53,6 @@ class AjaxResponseBuilder
         {
             $status = $ok ? "ok" : "failed";
         }
-
-        $this->urlGenerator = $urlGenerator;
-        $this->translator = $translator;
         $this->ok = $ok;
         $this->status = $status;
     }

--- a/src/Command/CommandHelper.php
+++ b/src/Command/CommandHelper.php
@@ -8,14 +8,8 @@ use Doctrine\Common\EventManager;
 
 class CommandHelper
 {
-    private Profiler $profiler;
-    private EventManager $eventManager;
-
-
-    public function __construct (Profiler $profiler, EventManager $eventManager)
+    public function __construct(private readonly Profiler $profiler, private readonly EventManager $eventManager)
     {
-        $this->profiler = $profiler;
-        $this->eventManager = $eventManager;
     }
 
 

--- a/src/Controller/BaseController.php
+++ b/src/Controller/BaseController.php
@@ -121,12 +121,12 @@ abstract class BaseController extends AbstractController
 
             return $data;
         }
-        catch (\JsonException $e)
+        catch (\JsonException $jsonException)
         {
             throw new InvalidJsonRequestException(
-                "Invalid JSON received, error: {$e->getMessage()}",
+                'Invalid JSON received, error: ' . $jsonException->getMessage(),
                 400,
-                $e
+                $jsonException
             );
         }
     }

--- a/src/Controller/BaseController.php
+++ b/src/Controller/BaseController.php
@@ -90,7 +90,7 @@ abstract class BaseController extends AbstractController
      */
     protected function getJsonRequestData (Request $request, bool $isRequired = true) : array
     {
-        if ("json" !== $request->getContentType())
+        if ("json" !== $request->getContentTypeFormat())
         {
             if (!$isRequired)
             {

--- a/src/Entity/Interfaces/SortableEntityInterface.php
+++ b/src/Entity/Interfaces/SortableEntityInterface.php
@@ -6,8 +6,6 @@ interface SortableEntityInterface extends EntityInterface
 {
     /**
      * Returns the sort order.
-     *
-     * @return int
      */
     public function getSortOrder () : ?int;
 

--- a/src/Entity/Tag/TagEntity.php
+++ b/src/Entity/Tag/TagEntity.php
@@ -11,22 +11,17 @@ use Symfony\Component\Validator\Constraints as Assert;
 
 /**
  * Base class for implementing tag entities
- *
- * @ORM\MappedSuperclass()
- *
- * @UniqueEntity(fields={"tag"}, message="becklyn.rad.tag.duplicate")
  */
+#[ORM\MappedSuperclass]
+#[UniqueEntity(fields: ['tag'], message: 'becklyn.rad.tag.duplicate')]
 abstract class TagEntity implements EntityInterface, TagInterface
 {
     use IdTrait;
 
-    /**
-     * @ORM\Column(name="tag", type="string", length=254, unique=true)
-     *
-     * @Assert\NotNull()
-     * @Assert\Length(max="254")
-     * @Assert\Regex(pattern="~^[a-z0-9\-_., ]+$~i", message="becklyn.rad.tag.pattern")
-     */
+    #[ORM\Column(name: 'tag', type: 'string', length: 254, unique: true)]
+    #[Assert\NotNull]
+    #[Assert\Length(max: 254)]
+    #[Assert\Regex(pattern: '~^[a-z0-9\-_., ]+$~i', message: 'becklyn.rad.tag.pattern')]
     private ?string $tag = null;
 
 

--- a/src/Entity/Tag/TagEntity.php
+++ b/src/Entity/Tag/TagEntity.php
@@ -21,7 +21,7 @@ abstract class TagEntity implements EntityInterface, TagInterface
     #[ORM\Column(name: 'tag', type: 'string', length: 254, unique: true)]
     #[Assert\NotNull]
     #[Assert\Length(max: 254)]
-    #[Assert\Regex(pattern: '~^[a-z0-9\-_., ]+$~i', message: 'becklyn.rad.tag.pattern')]
+    #[Assert\Regex(pattern: '~^[a-z0-9\\-_., ]+$~i', message: 'becklyn.rad.tag.pattern')]
     private ?string $tag = null;
 
 

--- a/src/Entity/Traits/IdTrait.php
+++ b/src/Entity/Traits/IdTrait.php
@@ -9,11 +9,9 @@ use Doctrine\ORM\Mapping as ORM;
  */
 trait IdTrait
 {
-    /**
-     * @ORM\Id()
-     * @ORM\GeneratedValue(strategy="AUTO")
-     * @ORM\Column(name="id", type="integer")
-     */
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    #[ORM\Column(name: 'id', type: 'integer')]
     private ?int $id = null;
 
 

--- a/src/Entity/Traits/SortOrderTrait.php
+++ b/src/Entity/Traits/SortOrderTrait.php
@@ -9,9 +9,7 @@ use Doctrine\ORM\Mapping as ORM;
  */
 trait SortOrderTrait
 {
-    /**
-     * @ORM\Column(name="sort_order", type="integer")
-     */
+    #[ORM\Column(name: 'sort_order', type: 'integer')]
     private ?int $sortOrder = null;
 
 

--- a/src/Entity/Traits/SortOrderTrait.php
+++ b/src/Entity/Traits/SortOrderTrait.php
@@ -15,7 +15,6 @@ trait SortOrderTrait
 
 
     /**
-     * @return int
      */
     public function getSortOrder () : ?int
     {

--- a/src/Entity/Traits/TimestampsTrait.php
+++ b/src/Entity/Traits/TimestampsTrait.php
@@ -9,15 +9,10 @@ use Doctrine\ORM\Mapping as ORM;
  */
 trait TimestampsTrait
 {
-    /**
-     * @ORM\Column(name="time_created", type="datetime_immutable")
-     */
+    #[ORM\Column(name: 'time_created', type: 'datetime_immutable')]
     private \DateTimeImmutable $timeCreated;
 
-
-    /**
-     * @ORM\Column(name="time_modified", type="datetime_immutable", nullable=true)
-     */
+    #[ORM\Column(name: 'time_modified', type: 'datetime_immutable', nullable: true)]
     private ?\DateTimeImmutable $timeModified = null;
 
 

--- a/src/Exception/Controller/InvalidJsonRequestException.php
+++ b/src/Exception/Controller/InvalidJsonRequestException.php
@@ -6,7 +6,7 @@ use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 
 final class InvalidJsonRequestException extends \RuntimeException implements HttpExceptionInterface
 {
-    private int $statusCode;
+    private readonly int $statusCode;
 
 
     /**

--- a/src/Exception/EntityRemovalBlockedException.php
+++ b/src/Exception/EntityRemovalBlockedException.php
@@ -9,7 +9,7 @@ namespace Becklyn\Rad\Exception;
 class EntityRemovalBlockedException extends \InvalidArgumentException implements RadException
 {
     /** @var object[] */
-    private array $entities;
+    private readonly array $entities;
 
 
     /**

--- a/src/Exception/LabeledEntityRemovalBlockedException.php
+++ b/src/Exception/LabeledEntityRemovalBlockedException.php
@@ -7,9 +7,6 @@ namespace Becklyn\Rad\Exception;
  */
 class LabeledEntityRemovalBlockedException extends EntityRemovalBlockedException implements LabeledExceptionInterface
 {
-    /** @var string */
-    private $frontendMessage;
-
     /**
      * {@inheritdoc}
      *
@@ -18,15 +15,14 @@ class LabeledEntityRemovalBlockedException extends EntityRemovalBlockedException
      * @param object|object[] $entities
      * @param string          $frontendMessage the #TranslationKey to use
      */
-    public function __construct ($entities, string $message, string $frontendMessage, ?\Throwable $previous = null)
+    public function __construct ($entities, string $message, private readonly string $frontendMessage, ?\Throwable $previous = null)
     {
         parent::__construct($entities, $message, $previous);
-        $this->frontendMessage = $frontendMessage;
     }
 
     /**
      */
-    public function getFrontendMessage ()
+    public function getFrontendMessage () : string
     {
         return $this->frontendMessage;
     }

--- a/src/Exception/UnexpectedTypeException.php
+++ b/src/Exception/UnexpectedTypeException.php
@@ -15,7 +15,7 @@ final class UnexpectedTypeException extends \InvalidArgumentException implements
         parent::__construct(\sprintf(
             'Expected argument of type %s, "%s" given',
             $expectedType,
-            \is_object($value) ? \get_class($value) : \gettype($value)
+            \get_debug_type($value)
         ));
     }
 }

--- a/src/Form/DeferredForm.php
+++ b/src/Form/DeferredForm.php
@@ -10,16 +10,10 @@ use Symfony\Component\Form\FormInterface;
  */
 final class DeferredForm
 {
-    private string $type;
-    private array $options;
-
-
     /**
      */
-    public function __construct (string $type, array $options = [])
+    public function __construct(private readonly string $type, private array $options = [])
     {
-        $this->type = $type;
-        $this->options = $options;
     }
 
 
@@ -39,9 +33,6 @@ final class DeferredForm
     }
 
 
-    /**
-     * @return static
-     */
     public function withOptions (array $options) : self
     {
         $modified = clone $this;

--- a/src/Form/Extension/ChoicePlaceholderFormExtension.php
+++ b/src/Form/Extension/ChoicePlaceholderFormExtension.php
@@ -14,13 +14,8 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  */
 class ChoicePlaceholderFormExtension extends AbstractTypeExtension
 {
-    private TranslatorInterface $translator;
-
-    /**
-     */
-    public function __construct (TranslatorInterface $translator)
+    public function __construct(private readonly TranslatorInterface $translator)
     {
-        $this->translator = $translator;
     }
 
     /**

--- a/src/Form/Extension/CollectionAdditionalOptionsFormExtension.php
+++ b/src/Form/Extension/CollectionAdditionalOptionsFormExtension.php
@@ -22,6 +22,7 @@ final class CollectionAdditionalOptionsFormExtension extends AbstractTypeExtensi
         {
             $builder->setAttribute($label, $options[$label]);
         }
+
         $builder->setAttribute("allow_sort", $options["allow_sort"]);
     }
 
@@ -34,6 +35,7 @@ final class CollectionAdditionalOptionsFormExtension extends AbstractTypeExtensi
         {
             $view->vars[$label] = $form->getConfig()->getAttribute($label);
         }
+
         $view->vars["allow_sort"] = $form->getConfig()->getAttribute("allow_sort");
     }
 

--- a/src/Form/FormErrorMapper.php
+++ b/src/Form/FormErrorMapper.php
@@ -11,14 +11,10 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  */
 class FormErrorMapper
 {
-    private TranslatorInterface $translator;
-
-
     /**
      */
-    public function __construct (TranslatorInterface $translator)
+    public function __construct(private readonly TranslatorInterface $translator)
     {
-        $this->translator = $translator;
     }
 
 
@@ -53,15 +49,12 @@ class FormErrorMapper
         foreach ($form->all() as $children)
         {
             $childErrors = $children->getErrors();
-            $fieldName = \ltrim("{$fieldPrefix}{$children->getName()}");
+            $fieldName = \ltrim($fieldPrefix . $children->getName());
 
             if (0 < \count($childErrors))
             {
                 $allErrors[$fieldName] = \array_map(
-                    function (FormError $error) use ($translationDomain)
-                    {
-                        return $this->translator->trans($error->getMessage(), [], $translationDomain);
-                    },
+                    fn(FormError $error) : string => $this->translator->trans($error->getMessage(), [], $translationDomain),
                     \iterator_to_array($childErrors)
                 );
             }

--- a/src/Integration/Profiler.php
+++ b/src/Integration/Profiler.php
@@ -6,12 +6,8 @@ use Symfony\Component\HttpKernel\Profiler\Profiler as SymfonyProfiler;
 
 class Profiler
 {
-    private ?SymfonyProfiler $profiler;
-
-
-    public function __construct (?SymfonyProfiler $profiler)
+    public function __construct(private readonly ?SymfonyProfiler $profiler)
     {
-        $this->profiler = $profiler;
     }
 
 

--- a/src/Pagination/Data/PaginatedList.php
+++ b/src/Pagination/Data/PaginatedList.php
@@ -9,14 +9,8 @@ namespace Becklyn\Rad\Pagination\Data;
  */
 class PaginatedList
 {
-    private iterable $list;
-    private Pagination $pagination;
-
-
-    public function __construct (iterable $list, Pagination $pagination)
+    public function __construct(private readonly iterable $list, private readonly Pagination $pagination)
     {
-        $this->list = $list;
-        $this->pagination = $pagination;
     }
 
 

--- a/src/Pagination/Data/Pagination.php
+++ b/src/Pagination/Data/Pagination.php
@@ -144,7 +144,6 @@ class Pagination
 
 
     /**
-     * @return Pagination
      */
     public function withNumberOfItems (int $numberOfItems) : self
     {

--- a/src/Pagination/Data/Pagination.php
+++ b/src/Pagination/Data/Pagination.php
@@ -9,20 +9,16 @@ use Becklyn\Rad\Exception\InvalidPaginationException;
  */
 class Pagination
 {
+    private readonly int $numberOfItems;
+    private readonly int $perPage;
+    private readonly int $maxPage;
+
     /**
      * WARNING: this value is unsanitized. You should never use it except for when passing it to a pagination with a
      * different number of elements. Always use the getter, which returns the normalized value. Also use the normalized
      * getter in internal methods to have correct calculation.
      */
-    private int $currentPage;
-    private int $numberOfItems;
-    private int $perPage;
-    private int $maxPage;
-
-
-    /**
-     */
-    public function __construct (int $currentPage, int $perPage = 50, int $numberOfItems = 0)
+    public function __construct (private readonly int $currentPage, int $perPage = 50, int $numberOfItems = 0)
     {
         if ($perPage <= 0)
         {
@@ -33,11 +29,9 @@ class Pagination
         {
             throw new InvalidPaginationException("Pagination can only be created for a positive number of items");
         }
-
-        $this->currentPage = $currentPage;
         $this->numberOfItems = $numberOfItems;
         $this->perPage = $perPage;
-        $this->maxPage = (int) \max(1, (int) \ceil($numberOfItems / $perPage));
+        $this->maxPage = \max(1, (int) \ceil($numberOfItems / $perPage));
     }
 
 

--- a/src/Route/DeferredRoute.php
+++ b/src/Route/DeferredRoute.php
@@ -21,10 +21,7 @@ class DeferredRoute implements LinkableInterface
 {
     public const OPTIONAL = true;
     public const REQUIRED = false;
-
-    private string $route;
     private array $parameters;
-    private int $referenceType;
 
 
     /**
@@ -32,11 +29,9 @@ class DeferredRoute implements LinkableInterface
      * @param array<string, string|int|float|EntityInterface|bool|null> $parameters    the parameters required for generating the route
      * @param int                                                       $referenceType The reference type to generate for this route
      */
-    public function __construct (string $route, array $parameters = [], int $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH)
+    public function __construct (private readonly string $route, array $parameters = [], private readonly int $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH)
     {
-        $this->route = $route;
         $this->parameters = $this->normalizeParameters($parameters);
-        $this->referenceType = $referenceType;
     }
 
 
@@ -121,7 +116,7 @@ class DeferredRoute implements LinkableInterface
 
         throw new InvalidRouteActionException(\sprintf(
             "Can't generate route for value of type '%s', only DeferredRoutes, strings and null are allowed.",
-            \is_object($value) ? \get_class($value) : \gettype($value)
+            \get_debug_type($value)
         ));
     }
 

--- a/src/Search/SimpleEntitySearchHelper.php
+++ b/src/Search/SimpleEntitySearchHelper.php
@@ -12,13 +12,11 @@ final class SimpleEntitySearchHelper
 {
     public const MODE_PREFIX = SimpleQueryTokenizer::MODE_PREFIX;
     public const MODE_EVERYWHERE = SimpleQueryTokenizer::MODE_EVERYWHERE;
-    private SimpleQueryTokenizer $tokenizer;
 
     /**
      */
-    public function __construct (SimpleQueryTokenizer $tokenizer)
+    public function __construct(private readonly SimpleQueryTokenizer $tokenizer)
     {
-        $this->tokenizer = $tokenizer;
     }
 
 

--- a/src/Search/SimpleQueryTokenizer.php
+++ b/src/Search/SimpleQueryTokenizer.php
@@ -14,7 +14,7 @@ final class SimpleQueryTokenizer
     /**
      * Transforms the given raw query to a mysql-ready and queryable query string
      */
-    public function transformToQuery (string $query, bool $mode = self::MODE_PREFIX)
+    public function transformToQuery (string $query, bool $mode = self::MODE_PREFIX) : string
     {
         $query = \trim($query);
 

--- a/src/Sortable/PropertiesSortableHandler.php
+++ b/src/Sortable/PropertiesSortableHandler.php
@@ -13,10 +13,12 @@ use Symfony\Component\PropertyAccess\PropertyAccessor;
  */
 final class PropertiesSortableHandler
 {
-    private SortableHandler $nested;
+    private readonly SortableHandler $nested;
+
     /** @var string[] */
-    private array $properties;
-    private PropertyAccessor $accessor;
+    private readonly array $properties;
+
+    private readonly PropertyAccessor $accessor;
 
 
     /**

--- a/src/Sortable/SortableHandler.php
+++ b/src/Sortable/SortableHandler.php
@@ -8,14 +8,8 @@ use Doctrine\ORM\QueryBuilder;
 
 final class SortableHandler
 {
-    private EntityRepository $repository;
-
-
-    /**
-     */
-    public function __construct (EntityRepository $repository)
+    public function __construct(private readonly EntityRepository $repository)
     {
-        $this->repository = $repository;
     }
 
 
@@ -82,7 +76,7 @@ final class SortableHandler
 
         // no $before reference element given, it should be moved to the end
         // -> just use next index
-        if (null === $before)
+        if (!$before instanceof SortableEntityInterface)
         {
             $entity->setSortOrder($index);
         }

--- a/src/Stats/NestedStatsCounter.php
+++ b/src/Stats/NestedStatsCounter.php
@@ -4,14 +4,12 @@ namespace Becklyn\Rad\Stats;
 
 final class NestedStatsCounter implements StatsCounterInterface
 {
-    private StatsCounterInterface $base;
-    private string $prefix;
+    private readonly string $prefix;
 
     /**
      */
-    public function __construct (StatsCounterInterface $base, string $prefix)
+    public function __construct (private readonly StatsCounterInterface $base, string $prefix)
     {
-        $this->base = $base;
         $this->prefix = \rtrim($prefix) . " ";
     }
 

--- a/src/Stats/StatsCounter.php
+++ b/src/Stats/StatsCounter.php
@@ -116,9 +116,9 @@ class StatsCounter implements StatsCounterInterface
         }
 
         $rows = \array_map(
-            function (array $row)
+            static function (array $row) : array
             {
-                $row[0] = "<fg=yellow>{$row[0]}</>";
+                $row[0] = \sprintf('<fg=yellow>%s</>', $row[0]);
                 return $row;
             },
             $this->toArray()
@@ -130,19 +130,19 @@ class StatsCounter implements StatsCounterInterface
 
         foreach ($this->critical as $line)
         {
-            $listing[] = "<fg=red>CRITICAL</> {$line}";
+            $listing[] = '<fg=red>CRITICAL</> ' . $line;
         }
 
         foreach ($this->warnings as $line)
         {
-            $listing[] = "<fg=yellow>WARNING</> {$line}";
+            $listing[] = '<fg=yellow>WARNING</> ' . $line;
         }
 
         if ($showDebug)
         {
             foreach ($this->debug as $line)
             {
-                $listing[] = "<fg=blue>DEBUG</> {$line}";
+                $listing[] = '<fg=blue>DEBUG</> ' . $line;
             }
         }
 

--- a/src/Tags/TagMatcher.php
+++ b/src/Tags/TagMatcher.php
@@ -13,17 +13,14 @@ class TagMatcher
     public const HAS_ANY_TAG = false;
     public const HAS_ALL_TAGS = true;
 
-    private array $tags;
-    private string $selector;
-    private bool $selectionMode;
+    private readonly array $tags;
+
     private bool $mustJoin = true;
 
 
-    public function __construct (iterable $tags, string $selector, bool $selectionMode = self::HAS_ALL_TAGS)
+    public function __construct (iterable $tags, private readonly string $selector, private readonly bool $selectionMode = self::HAS_ALL_TAGS)
     {
         $this->tags = self::normalizeTagList($tags);
-        $this->selectionMode = $selectionMode;
-        $this->selector = $selector;
     }
 
 
@@ -124,7 +121,7 @@ class TagMatcher
 
             throw new TagNormalizationException(\sprintf(
                 "Can't transform value of type '%s'.",
-                \is_object($tag) ? \get_class($tag) : \gettype($tag)
+                \get_debug_type($tag)
             ));
         }
 

--- a/src/Translation/BackendTranslator.php
+++ b/src/Translation/BackendTranslator.php
@@ -34,7 +34,7 @@ class BackendTranslator
     /**
      * Translates all messages.
      *
-     * @param (string|null|array)[] $messages
+     * @param (string|array|null)[] $messages
      *
      * @return (string|null)[]
      */

--- a/src/Translation/BackendTranslator.php
+++ b/src/Translation/BackendTranslator.php
@@ -9,14 +9,8 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  */
 class BackendTranslator
 {
-    private TranslatorInterface $translator;
-
-
-    /**
-     */
-    public function __construct (TranslatorInterface $translator)
+    public function __construct(private readonly TranslatorInterface $translator)
     {
-        $this->translator = $translator;
     }
 
 

--- a/src/Translation/DeferredTranslation.php
+++ b/src/Translation/DeferredTranslation.php
@@ -18,21 +18,14 @@ class DeferredTranslation
     public const OPTIONAL = true;
     public const REQUIRED = false;
 
-    private string $id;
-    private array $parameters;
-    private string $domain;
-
 
     /**
      * @param string $id         Translation key #TranslationKey
      * @param array  $parameters Translation parameters
      * @param string $domain     Translation domain #TranslationDomain
      */
-    public function __construct (string $id, array $parameters = [], string $domain = "messages")
+    public function __construct(private readonly string $id, private array $parameters = [], private readonly string $domain = "messages")
     {
-        $this->id = $id;
-        $this->parameters = $parameters;
-        $this->domain = $domain;
     }
 
 
@@ -101,7 +94,7 @@ class DeferredTranslation
 
         throw new InvalidTranslationActionException(\sprintf(
             "Can't translate value of type '%s', only DeferredTranslations, strings and null are allowed.",
-            \is_object($value) ? \get_class($value) : \gettype($value)
+            \get_debug_type($value)
         ));
     }
 
@@ -177,5 +170,6 @@ class DeferredTranslation
     {
         return new self($id, $parameters, "backend");
     }
+
     //endregion
 }

--- a/src/Twig/RadTwigExtension.php
+++ b/src/Twig/RadTwigExtension.php
@@ -14,27 +14,15 @@ use Twig\TwigFunction;
 
 class RadTwigExtension extends AbstractExtension
 {
-    private DataContainer $dataContainer;
-    private TranslatorInterface $translator;
-    private ?LinkableHandlerInterface $linkableHandler;
-
-
-    public function __construct (
-        DataContainer $dataContainer,
-        TranslatorInterface $translator,
-        ?LinkableHandlerInterface $linkableHandler = null
-    )
+    public function __construct(private readonly DataContainer $dataContainer, private readonly TranslatorInterface $translator, private readonly ?LinkableHandlerInterface $linkableHandler = null)
     {
-        $this->dataContainer = $dataContainer;
-        $this->translator = $translator;
-        $this->linkableHandler = $linkableHandler;
     }
 
 
     public function appendToKey (array $map, string $key, string $append) : array
     {
         $value = $map[$key] ?? "";
-        $map[$key] = \trim("{$value} {$append}");
+        $map[$key] = \trim(\sprintf('%s %s', $value, $append));
         return $map;
     }
 
@@ -104,9 +92,9 @@ class RadTwigExtension extends AbstractExtension
 
             return $this->linkableHandler->generateUrl($link);
         }
-        catch (UnexpectedTypeException $e)
+        catch (UnexpectedTypeException $unexpectedTypeException)
         {
-            throw new \LogicException("Could not generate URL for LinkableInterface due to an error.", 500, $e);
+            throw new \LogicException("Could not generate URL for LinkableInterface due to an error.", 500, $unexpectedTypeException);
         }
     }
 

--- a/tests/Ajax/AjaxResponseBuilderTest.php
+++ b/tests/Ajax/AjaxResponseBuilderTest.php
@@ -362,7 +362,7 @@ final class AjaxResponseBuilderTest extends TestCase
     /**
      * @dataProvider provideDefaultStatus
      */
-    public function testDefaultStatus (bool $ok, string $expected)
+    public function testDefaultStatus (bool $ok, string $expected): void
     {
         $builder = new AjaxResponseBuilder(
             $this->getMockBuilder(TranslatorInterface::class)->disableOriginalConstructor()->getMock(),

--- a/tests/Form/DeferredFormTest.php
+++ b/tests/Form/DeferredFormTest.php
@@ -32,9 +32,6 @@ final class DeferredFormTest extends TestCase
     }
 
 
-    /**
-     * @return iterable
-     */
     public function provideCloneWithOptions () : iterable
     {
         yield "simple merge" => [

--- a/tests/Html/DataContainerTest.php
+++ b/tests/Html/DataContainerTest.php
@@ -20,6 +20,7 @@ class DataContainerTest extends TestCase
             $dataContainer->renderToHtml(["<b>" => 2], "test")
         );
     }
+
     /**
      *
      */

--- a/tests/Pagination/Data/PaginationTest.php
+++ b/tests/Pagination/Data/PaginationTest.php
@@ -7,9 +7,6 @@ use PHPUnit\Framework\TestCase;
 
 class PaginationTest extends TestCase
 {
-    /**
-     * @return array
-     */
     public function provideValidMaxPage () : array
     {
         return [
@@ -26,10 +23,6 @@ class PaginationTest extends TestCase
 
     /**
      * @dataProvider provideValidMaxPage
-     *
-     * @param int $numberOfItems
-     * @param int $itemsPerPage
-     * @param int $expectedMaxPage
      */
     public function testValidMaxPage (int $numberOfItems, int $itemsPerPage, int $expectedMaxPage) : void
     {
@@ -38,9 +31,6 @@ class PaginationTest extends TestCase
     }
 
 
-    /**
-     * @return array
-     */
     public function provideInvalid () : array
     {
         return [
@@ -53,9 +43,6 @@ class PaginationTest extends TestCase
 
     /**
      * @dataProvider provideInvalid
-     *
-     * @param int $numberOfItems
-     * @param int $itemsPerPage
      */
     public function testInvalid (int $numberOfItems, int $itemsPerPage) : void
     {
@@ -96,9 +83,6 @@ class PaginationTest extends TestCase
     }
 
 
-    /**
-     * @return array
-     */
     public function provideCurrent () : array
     {
         return [

--- a/tests/Path/PathHelperTest.php
+++ b/tests/Path/PathHelperTest.php
@@ -7,10 +7,7 @@ use PHPUnit\Framework\TestCase;
 
 class PathHelperTest extends TestCase
 {
-    /**
-     * @return array
-     */
-    public function providerVariations ()
+    public function providerVariations (): array
     {
         return [
             [["a", "b", "c"], "a/b/c"],

--- a/tests/Route/DeferredRouteTest.php
+++ b/tests/Route/DeferredRouteTest.php
@@ -31,9 +31,6 @@ class DeferredRouteTest extends TestCase
     }
 
 
-    /**
-     * @return iterable
-     */
     public function provideCloneWithParameters () : iterable
     {
         yield "simple merge" => [
@@ -80,7 +77,7 @@ class DeferredRouteTest extends TestCase
     {
         $entity = new class implements EntityInterface
         {
-            public function getId () : ?int { return 123; }
+            public function getId () : int { return 123; }
             public function isNew () : bool { return false; }
         };
 
@@ -106,13 +103,13 @@ class DeferredRouteTest extends TestCase
     {
         $entity1 = new class implements EntityInterface
         {
-            public function getId () : ?int { return 123; }
+            public function getId () : int { return 123; }
             public function isNew () : bool { return false; }
         };
 
         $entity2 = new class implements EntityInterface
         {
-            public function getId () : ?int { return 234; }
+            public function getId () : int { return 234; }
             public function isNew () : bool { return false; }
         };
 
@@ -156,7 +153,7 @@ class DeferredRouteTest extends TestCase
      *
      * @param mixed $value
      */
-    public function testValidRouteValue ($value, ?string $expected) : void
+    public function testValidRouteValue (string|DeferredRoute|null $value, ?string $expected) : void
     {
         $router = $this->getMockBuilder(RouterInterface::class)
             ->getMock();
@@ -187,7 +184,7 @@ class DeferredRouteTest extends TestCase
      *
      * @param mixed $value
      */
-    public function testInvalidRouteValue ($value) : void
+    public function testInvalidRouteValue (bool|int|\stdClass $value) : void
     {
         $this->expectException(InvalidRouteActionException::class);
 
@@ -218,7 +215,7 @@ class DeferredRouteTest extends TestCase
     /**
      * @dataProvider provideValueVariations
      */
-    public function testIsValid (bool $expected, $value, bool $isOptional) : void
+    public function testIsValid (bool $expected, string|DeferredRoute|int|bool|null $value, bool $isOptional) : void
     {
         self::assertSame($expected, DeferredRoute::isValidValue($value, $isOptional));
     }
@@ -227,7 +224,7 @@ class DeferredRouteTest extends TestCase
     /**
      * @dataProvider provideValueVariations
      */
-    public function testEnsureValid (bool $shouldBeOk, $value, bool $isOptional) : void
+    public function testEnsureValid (bool $shouldBeOk, string|DeferredRoute|int|bool|null $value, bool $isOptional) : void
     {
         if (!$shouldBeOk)
         {

--- a/tests/Sortable/PropertiesSortableHandlerTest.php
+++ b/tests/Sortable/PropertiesSortableHandlerTest.php
@@ -56,6 +56,7 @@ class PropertiesSortableHandlerTest extends TestCase
         $sortable = new PropertiesSortableHandler($repository);
         $sortable->setNextSortOrder($entity);
     }
+
     //endregion
 
 
@@ -97,5 +98,6 @@ class PropertiesSortableHandlerTest extends TestCase
         $sortable = new PropertiesSortableHandler($repository, "a");
         self::assertFalse($sortable->sortElementBefore($entity, $before));
     }
+
     //endregion
 }

--- a/tests/Sortable/SortableHandlerTest.php
+++ b/tests/Sortable/SortableHandlerTest.php
@@ -16,9 +16,6 @@ class SortableHandlerTest extends TestCase
     use SortableTestTrait;
 
     //region Next Sort Order
-    /**
-     * @return array
-     */
     public function provideNextSortOrder () : array
     {
         return [
@@ -31,9 +28,6 @@ class SortableHandlerTest extends TestCase
 
     /**
      * @dataProvider provideNextSortOrder
-     *
-     * @param int|null $returnValue
-     * @param int      $expected
      */
     public function testNextSortOrder (?int $returnValue, int $expected) : void
     {
@@ -61,6 +55,7 @@ class SortableHandlerTest extends TestCase
 
         self::assertSame($expected, $sortable->getNextSortOrder());
     }
+
     //endregion
 
 
@@ -110,6 +105,7 @@ class SortableHandlerTest extends TestCase
         $sortable = new SortableHandler($repository);
         $sortable->fixSortOrder([$entityExcluded1, $entityExcluded2]);
     }
+
     //endregion
 
 
@@ -198,6 +194,7 @@ class SortableHandlerTest extends TestCase
         $success = $sortable->sortElementBefore($entity, $entity);
         self::assertFalse($success);
     }
+
     //endregion
 
 
@@ -266,5 +263,6 @@ class SortableHandlerTest extends TestCase
             "t.obj = :where_value_2",
         ], $andX->getParts());
     }
+
     //endregion
 }

--- a/tests/Sortable/SortableTestTrait.php
+++ b/tests/Sortable/SortableTestTrait.php
@@ -10,27 +10,17 @@ use Doctrine\ORM\QueryBuilder;
 
 trait SortableTestTrait
 {
-    /**
-     * @param int      $id
-     * @param int|null $sortOrder
-     *
-     * @return SortableEntityInterface
-     */
     private function createEntity (int $id, ?int $sortOrder = null) : SortableEntityInterface
     {
         return new class ($id, $sortOrder) implements SortableEntityInterface
         {
-            private int $id;
-            private ?int $sortOrder;
 
-            public function __construct (int $id, ?int $sortOrder = null)
+            public function __construct(private readonly int $id, private ?int $sortOrder = null)
             {
-                $this->id = $id;
-                $this->sortOrder = $sortOrder;
             }
 
 
-            public function getId () : ?int
+            public function getId () : int
             {
                 return $this->id;
             }
@@ -55,33 +45,16 @@ trait SortableTestTrait
         };
     }
 
-    /**
-     * @param int      $id
-     * @param int|null $sortOrder
-     *
-     * @return SortableEntityInterface
-     */
     private function createEntityWithProperties (int $id, $a, $b, $c, ?int $sortOrder = null) : SortableEntityInterface
     {
         return new class ($id, $sortOrder, $a, $b, $c) implements SortableEntityInterface
         {
-            private int $id;
-            private ?int $sortOrder;
-            private $a;
-            private $b;
-            private $c;
-
-            public function __construct (int $id, ?int $sortOrder, $a, $b, $c)
+            public function __construct(private readonly int $id, private ?int $sortOrder, private $a, private $b, private $c)
             {
-                $this->id = $id;
-                $this->sortOrder = $sortOrder;
-                $this->a = $a;
-                $this->b = $b;
-                $this->c = $c;
             }
 
 
-            public function getId () : ?int
+            public function getId () : int
             {
                 return $this->id;
             }
@@ -122,11 +95,6 @@ trait SortableTestTrait
     }
 
 
-    /**
-     * @param int $number
-     *
-     * @return array
-     */
     private function createEntities (int $number) : array
     {
         $result = [];
@@ -142,8 +110,6 @@ trait SortableTestTrait
 
     /**
      * @param SortableEntityInterface[] $entities
-     *
-     * @return array
      */
     private function mapEntities (array $entities) : array
     {
@@ -188,7 +154,7 @@ trait SortableTestTrait
 
         \usort(
             $entities,
-            static fn (SortableEntityInterface $left, SortableEntityInterface $right) => $left->getSortOrder() - $right->getSortOrder()
+            static fn (SortableEntityInterface $left, SortableEntityInterface $right): int => $left->getSortOrder() - $right->getSortOrder()
         );
 
         $query

--- a/tests/Translation/DeferredTranslationTest.php
+++ b/tests/Translation/DeferredTranslationTest.php
@@ -29,9 +29,6 @@ class DeferredTranslationTest extends TestCase
     }
 
 
-    /**
-     * @return iterable
-     */
     public function provideCloneWithParameters () : iterable
     {
         yield "simple merge" => [
@@ -90,7 +87,7 @@ class DeferredTranslationTest extends TestCase
      *
      * @param mixed $value
      */
-    public function testValidTranslateValue ($value, ?string $expected) : void
+    public function testValidTranslateValue (string|DeferredTranslation|null $value, ?string $expected) : void
     {
         $translator = $this->getMockBuilder(TranslatorInterface::class)
             ->getMock();
@@ -121,7 +118,7 @@ class DeferredTranslationTest extends TestCase
      *
      * @param mixed $value
      */
-    public function testInvalidTranslateValue ($value) : void
+    public function testInvalidTranslateValue (bool|int|\stdClass $value) : void
     {
         $this->expectException(InvalidTranslationActionException::class);
 
@@ -152,7 +149,7 @@ class DeferredTranslationTest extends TestCase
     /**
      * @dataProvider provideValueVariations
      */
-    public function testIsValidValue (bool $expected, $value, bool $required) : void
+    public function testIsValidValue (bool $expected, string|DeferredTranslation|int|bool|null $value, bool $required) : void
     {
         self::assertSame($expected, DeferredTranslation::isValidValue($value, $required));
     }
@@ -161,7 +158,7 @@ class DeferredTranslationTest extends TestCase
     /**
      * @dataProvider provideValueVariations
      */
-    public function testEnsureValidValue (bool $shouldBeOk, $value, bool $isOptional) : void
+    public function testEnsureValidValue (bool $shouldBeOk, string|DeferredTranslation|int|bool|null $value, bool $isOptional) : void
     {
         if (!$shouldBeOk)
         {

--- a/tests/Twig/RadTwigExtensionTest.php
+++ b/tests/Twig/RadTwigExtensionTest.php
@@ -29,9 +29,6 @@ class RadTwigExtensionTest extends TestCase
     }
 
 
-    /**
-     * @return array
-     */
     public function provideClassnames () : array
     {
         return [
@@ -61,9 +58,6 @@ class RadTwigExtensionTest extends TestCase
 
     /**
      * @dataProvider provideClassnames
-     *
-     * @param array  $classnames
-     * @param string $expected
      */
     public function testClassnames (array $classnames, string $expected) : void
     {


### PR DESCRIPTION
| Q             | A
| ------------- | --------------------------------------------------------------------- |
| BC breaks?    | yes                                                                |
| New feature?  | no |
| Improvement?  | no |
| Bug fix?      | no                                                                |
| Deprecations? | yes |
| Docs PR       | - |

-  (breaking) Minimum PHP version increased to 8.1.
-  (breaking) All Doctrine ORM annotations converted to PHP 8 attributes.
